### PR TITLE
Update DateFormats and ResolverStyle

### DIFF
--- a/src/main/java/seedu/duke/common/Validators.java
+++ b/src/main/java/seedu/duke/common/Validators.java
@@ -4,7 +4,10 @@ import java.math.BigDecimal;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
 
 import seedu.duke.exception.CustomException;
 import seedu.duke.record.RecordList;
@@ -13,17 +16,37 @@ import static seedu.duke.common.Constant.FINUX_LOGGER;
 public class Validators {
     private static final String KEYWORD_TODAY = "today";
     private static final String LOGGER_OKAY_MESSAGE = "index validation success";
+    private static final long ERA_AD = 1;
 
-    // @@author marklowsk-reused
-    // Reused from https://github.com/marklowsk/ip/blob/master/src/main/java/duke/common/Utils.java
     private static final DateTimeFormatter[] POSSIBLE_DATE_FORMATS = {
-        DateTimeFormatter.ofPattern("ddMMyyyy"),
-        DateTimeFormatter.ofPattern("d.M.yyyy"),
-        DateTimeFormatter.ofPattern("d-M-yyyy"),
-        DateTimeFormatter.ofPattern("d/M/yyyy"),
-        DateTimeFormatter.ofPattern("yyyy.M.d"),
-        DateTimeFormatter.ofPattern("yyyy-M-d"),
-        DateTimeFormatter.ofPattern("yyyy/M/d")
+        new DateTimeFormatterBuilder().appendPattern("ddMMyyyy")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("d.M.yyyy")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("d-M-yyyy")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("d/M/yyyy")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("yyyy.M.d")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("yyyy-M-d")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT),
+        new DateTimeFormatterBuilder().appendPattern("yyyy/M/d")
+                                      .parseDefaulting(ChronoField.ERA, ERA_AD)
+                                      .toFormatter()
+                                      .withResolverStyle(ResolverStyle.STRICT)
     };
 
     // @@author marklowsk-reused
@@ -38,7 +61,7 @@ public class Validators {
 
     // @@author marklowsk-reused
     // Reused from https://github.com/marklowsk/ip/blob/master/src/main/java/duke/common/Utils.java
-    // Utils.parseDate(String) with new additions.
+    //   Utils.parseDate(String) with new additions.
     /**
      * Parses dateInput into a LocalDateTime object.
      * Returns null if dateInput cannot be parsed into a LocalDateTime object.
@@ -58,7 +81,7 @@ public class Validators {
                 return date;
             }
         }
-        throw new DateTimeException("input \"" + dateInput + "\" is not an acceptable Date Format.");
+        throw new DateTimeException("input \"" + dateInput + "\" is an invalid date.");
     }
 
     /**

--- a/src/test/java/seedu/duke/common/ValidatorsTest.java
+++ b/src/test/java/seedu/duke/common/ValidatorsTest.java
@@ -14,7 +14,7 @@ class ValidatorsTest {
     @Test
     void validateDate_properDateFormat_success() {
         String[] dateStrings = {
-            "13122011", "13.1.2011", "13-1-2011", "13/1/2011", "30120000",
+            "13122011", "13.1.2011", "13-1-2011", "13/1/2011", "30120001",
             "2011.1.13", "2011-1-13", "2011/1/13", "2020.2.29", "today"
         };
         try {
@@ -30,7 +30,7 @@ class ValidatorsTest {
     void validateDate_improperDateFormat() {
         int counter = 0;
         String[] dateStrings = {
-            "12345678", "13.13.2011", "13-13-2011", "13 13 2011",
+            "12345678", "13.13.2011", "13-13-2011", "13 13 2011", "30120000",
             "2011 1 13", "2011-1/13", "2011/1.13", "2020.2.30", "today123"
         };
         for (String d : dateStrings) {

--- a/src/test/java/seedu/duke/common/ValidatorsTest.java
+++ b/src/test/java/seedu/duke/common/ValidatorsTest.java
@@ -14,8 +14,8 @@ class ValidatorsTest {
     @Test
     void validateDate_properDateFormat_success() {
         String[] dateStrings = {
-            "13122011", "13.1.2011", "13-1-2011", "13/1/2011",
-            "2011.1.13", "2011-1-13", "2011/1/13", "today"
+            "13122011", "13.1.2011", "13-1-2011", "13/1/2011", "30120000",
+            "2011.1.13", "2011-1-13", "2011/1/13", "2020.2.29", "today"
         };
         try {
             for (String d : dateStrings) {
@@ -28,11 +28,10 @@ class ValidatorsTest {
 
     @Test
     void validateDate_improperDateFormat() {
-        final int finalCount = 8;
         int counter = 0;
         String[] dateStrings = {
             "12345678", "13.13.2011", "13-13-2011", "13 13 2011",
-            "2011 1 13", "2011-1/13", "2011/1.13", "today123"
+            "2011 1 13", "2011-1/13", "2011/1.13", "2020.2.30", "today123"
         };
         for (String d : dateStrings) {
             try {
@@ -41,7 +40,7 @@ class ValidatorsTest {
                 counter++;
             }
         }
-        if (finalCount != counter) {
+        if (dateStrings.length != counter) {
             fail();
         }
     }


### PR DESCRIPTION
BugFix for `DateFormatter` resolver.
Fixes #166.
Does not solve #188 due to year 0000 being disallowed (Year starts from 0001 - era AD).